### PR TITLE
Fix #65, Change argument name in implementation to patch prototype

### DIFF
--- a/fsw/src/sbn_app.c
+++ b/fsw/src/sbn_app.c
@@ -1681,7 +1681,7 @@ void SBN_AppMain(void)
  * @param[in] MsgType The type of the message (application data, SBN protocol)
  * @param[in] ProcessorID The ProcessorID to send this message to.
  * @param[in] SpacecraftID The SpacecraftID to send this message to.
- * @param[in] MsgSize The size of the message (in bytes).
+ * @param[in] MsgSz The size of the message (in bytes).
  * @param[in] Msg The message contents.
  *
  * @return SBN_SUCCESS on successful processing, SBN_ERROR otherwise
@@ -1690,7 +1690,7 @@ SBN_Status_t SBN_ProcessNetMsg(SBN_NetInterface_t *Net,
                                SBN_MsgType_t       MsgType,
                                CFE_ProcessorID_t   ProcessorID,
                                CFE_SpacecraftID_t  SpacecraftID,
-                               SBN_MsgSz_t         MsgSize,
+                               SBN_MsgSz_t         MsgSz,
                                void               *Msg)
 {
     static const char    FAIL_PREFIX[] = "ERROR: could not process peer message:";


### PR DESCRIPTION
Change a function argument name to match the name for the same argument in the function prototype.

Adjust documentation to match.

Note that the argument is unused, so there's no need to adjust the function implementation beyond the argument name.

Note also that the name `MsgSz` is not present in the implementation of that function, so we know it does not overlap with any names within the same scope.