### PR TITLE
Fix #63, Adds osal_id_t type to cov test int

### DIFF
--- a/unit-test/coveragetest/coveragetest_sbn_app.c
+++ b/unit-test/coveragetest/coveragetest_sbn_app.c
@@ -2296,7 +2296,7 @@ static void ReloadConfTbl_Nominal(void)
     /* Set up mutex operations */
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemTake), 1, OS_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemGive), 1, OS_SUCCESS);
-    SBN.ConfMutex = 1; /* Valid non-zero value */
+    SBN.ConfMutex = OS_ObjectIdFromInteger(1); /* Valid non-zero value */
 
     /* Set up for Cleanup */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_DeletePipe), 1, CFE_SUCCESS);


### PR DESCRIPTION
- Fixes #63, Obtains the osal_id_t for the int getting assigned to CFE_ES_MutexID_t (CFE_ES_ObjectID_t, which is osal_id_t) in a sbn coverage test. This change allows for unit tests to compile successfully `ENABLE_UNIT_TESTS`.

Additional Context:
This update exposes missing coverage for the app. Documented in https://github.com/nasa/SBN/issues/76