### PR TITLE
ci: declare workflow-level `contents: read` on format-check and codeql-build

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   codeql:
     name: Codeql Analysis

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -13,6 +13,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: Run format check


### PR DESCRIPTION
Both workflows just run code checks. No GitHub API writes from the workflow itself, so workflow-level `contents: read` is the right cap.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening shape. YAML validated locally.