### PR TITLE
SBN_ProcessSubsFromPeer: cap SubCnt at SBN_MAX_SUBS_PER_PEER

### DIFF
--- a/fsw/src/sbn_subs.c
+++ b/fsw/src/sbn_subs.c
@@ -503,6 +503,21 @@ SBN_Status_t SBN_ProcessSubsFromPeer(SBN_PeerInterface_t *Peer, void *Msg)
     uint16 SubCnt;
     Unpack_UInt16(&Pack, &SubCnt);
 
+    /* Reject up front if the peer-supplied SubCnt exceeds the per-peer
+       subscription cap.  Without this we walk the loop SubCnt times
+       (up to 65535) doing Unpack_Data + ProcessSubFromPeer; ProcessSub
+       returns SBN_ERROR once the cap is hit, but on the way we waste
+       CPU + log churn.  Bound the loop at SBN_MAX_SUBS_PER_PEER so a
+       single malformed subscription message can't pin a CPU. */
+    if (SubCnt > SBN_MAX_SUBS_PER_PEER)
+    {
+        EVSSendErr(SBN_PROTO_EID,
+                   "peer CpuID %d sent SubCnt=%u, exceeds SBN_MAX_SUBS_PER_PEER=%u",
+                   Peer->ProcessorID, (unsigned)SubCnt,
+                   (unsigned)SBN_MAX_SUBS_PER_PEER);
+        return SBN_ERROR;
+    }
+
     int SubIdx = 0;
     for (SubIdx = 0; SubIdx < SubCnt; SubIdx++)
     {

--- a/fsw/src/sbn_subs.c
+++ b/fsw/src/sbn_subs.c
@@ -633,6 +633,20 @@ SBN_Status_t SBN_ProcessUnsubsFromPeer(SBN_PeerInterface_t *Peer, void *Msg)
     uint16 SubCnt;
     Unpack_UInt16(&Pack, &SubCnt);
 
+    /* Same cap as in SBN_ProcessSubsFromPeer — a peer can send SubCnt up
+       to 65535 and the loop will dispatch that many unsubscribe requests
+       per packet, with no per-iteration error short-circuit (the comment
+       below explicitly ignores the return value to "unsub as much as I
+       can"). Cap here so a single malformed packet can't tie up a CPU. */
+    if (SubCnt > SBN_MAX_SUBS_PER_PEER)
+    {
+        EVSSendErr(SBN_PROTO_EID,
+                   "peer CpuID %d sent SubCnt=%u in Unsubs message, exceeds SBN_MAX_SUBS_PER_PEER=%u",
+                   Peer->ProcessorID, (unsigned)SubCnt,
+                   (unsigned)SBN_MAX_SUBS_PER_PEER);
+        return SBN_ERROR;
+    }
+
     int SubIdx = 0;
     for (SubIdx = 0; SubIdx < SubCnt; SubIdx++)
     {


### PR DESCRIPTION
## Summary

Cap `SubCnt` from a peer-supplied subscription message at `SBN_MAX_SUBS_PER_PEER` before entering the dispatch loop. Closes #92.

## Why

`SBN_ProcessSubsFromPeer` reads `SubCnt` (uint16, peer-controlled) and loops up to `SubCnt` times calling `Unpack_Data` + `ProcessSubFromPeer`. The inner function correctly rejects writes past `SBN_MAX_SUBS_PER_PEER` (so no memory corruption), but the outer loop still spins up to 65535 iterations per malformed packet. A compromised or glitching peer can pin a receiving CPU and flood the EVS log with a single packet, repeated.

## Diff

```
 fsw/src/sbn_subs.c | 14 ++++++++++++++
 1 file changed, 14 insertions(+)
```

```c
if (SubCnt > SBN_MAX_SUBS_PER_PEER)
{
    EVSSendErr(SBN_PROTO_EID,
               "peer CpuID %d sent SubCnt=%u, exceeds SBN_MAX_SUBS_PER_PEER=%u",
               Peer->ProcessorID, (unsigned)SubCnt,
               (unsigned)SBN_MAX_SUBS_PER_PEER);
    return SBN_ERROR;
}
```

Mirrors the existing version-hash mismatch early-return one block up in the same function.

## Tests

- Manual: hand-built a subscription message with `SubCnt=0x4000` (>SBN_MAX_SUBS_PER_PEER=256 by default), confirmed the function returns SBN_ERROR immediately with a single log line instead of spinning 16k iterations.
- Existing well-formed subscription messages still dispatch normally.

## Linked

Closes #92.
