### PR TITLE
Fix #94, Initialize Variables in sbn_subs.c and sbn_app.c

### DIFF
--- a/fsw/src/sbn_app.c
+++ b/fsw/src/sbn_app.c
@@ -128,7 +128,8 @@ bool SBN_UnpackMsg(void               *SBNBuf,
                    CFE_SpacecraftID_t *SpacecraftIDPtr,
                    void               *Msg)
 {
-    uint8  t = 0;
+    *MsgSzPtr = 0;
+    uint8  t  = 0;
     Pack_t Pack;
     Pack_Init(&Pack, SBNBuf, SBN_MAX_PACKED_MSG_SZ, false);
     Unpack_UInt32(&Pack, MsgSzPtr);
@@ -1059,7 +1060,7 @@ static SBN_Status_t WaitForWakeup(int32 iTimeOut)
  */
 static cpuaddr LoadConf_Module(SBN_Module_Entry_t *e, CFE_ES_ModuleID_t *ModuleIDPtr)
 {
-    cpuaddr StructAddr;
+    cpuaddr StructAddr = 0;
 
     EVSSendInfo(SBN_TBL_EID, "checking if module (%s) already loaded", e->Name);
     if (OS_SymbolLookup(&StructAddr, e->LibSymbol) != OS_SUCCESS) /* try loading it if it's not already loaded */
@@ -1579,10 +1580,10 @@ static SBN_Status_t Cleanup(void)
 void SBN_AppMain(void)
 {
     static const char FAIL_PREFIX[] = "ERROR: could not start SBN:";
-    CFE_ES_TaskInfo_t TaskInfo;
-    uint32            Status    = CFE_SUCCESS;
-    uint32            RunStatus = CFE_ES_RunStatus_APP_RUN;
-    CFE_ES_AppId_t    AppID     = CFE_ES_APPID_UNDEFINED;
+    CFE_ES_TaskInfo_t TaskInfo      = { 0 };
+    uint32            Status        = CFE_SUCCESS;
+    uint32            RunStatus     = CFE_ES_RunStatus_APP_RUN;
+    CFE_ES_AppId_t    AppID         = CFE_ES_APPID_UNDEFINED;
 
     if (CFE_EVS_Register(NULL, 0, CFE_EVS_NO_FILTER) != CFE_SUCCESS)
         return;
@@ -1596,7 +1597,7 @@ void SBN_AppMain(void)
     SBN.AppID = AppID;
 
     /* load my TaskName so I can ignore messages I send out to SB */
-    CFE_ES_TaskId_t TskId;
+    CFE_ES_TaskId_t TskId = CFE_ES_TASKID_UNDEFINED;
     CFE_ES_GetTaskID(&TskId);
     if ((Status = CFE_ES_GetTaskInfo(&TaskInfo, TskId)) != CFE_SUCCESS)
     {

--- a/fsw/src/sbn_subs.c
+++ b/fsw/src/sbn_subs.c
@@ -330,9 +330,9 @@ SBN_Status_t SBN_CheckSubscriptionPipe(void)
 {
     CFE_Status_t CFE_Status = CFE_SUCCESS;
 
-    CFE_SB_AllSubscriptionsTlm_t   *MsgPtr       = NULL; /* largest message format */
-    CFE_SB_SingleSubscriptionTlm_t *SingleMsgPtr = NULL; /* utility "cast" */
-    CFE_SB_MsgId_t                  MsgId;
+    CFE_SB_AllSubscriptionsTlm_t   *MsgPtr             = NULL; /* largest message format */
+    CFE_SB_SingleSubscriptionTlm_t *SingleMsgPtr       = NULL; /* utility "cast" */
+    CFE_SB_MsgId_t                  MsgId              = CFE_SB_INVALID_MSG_ID;
     static CFE_SB_MsgId_t           SB_ONESUB_TLM_MID  = CFE_SB_MSGID_RESERVED;
     static CFE_SB_MsgId_t           SB_ALLSUBS_TLM_MID = CFE_SB_MSGID_RESERVED;
 
@@ -500,15 +500,15 @@ SBN_Status_t SBN_ProcessSubsFromPeer(SBN_PeerInterface_t *Peer, void *Msg)
         return SBN_ERROR;
     }
 
-    uint16 SubCnt;
+    uint16 SubCnt = 0;
     Unpack_UInt16(&Pack, &SubCnt);
 
     int SubIdx = 0;
     for (SubIdx = 0; SubIdx < SubCnt; SubIdx++)
     {
-        CFE_SB_MsgId_t MsgID;
+        CFE_SB_MsgId_t MsgID = CFE_SB_INVALID_MSG_ID;
         Unpack_MsgID(&Pack, &MsgID);
-        CFE_SB_Qos_t QoS;
+        CFE_SB_Qos_t QoS = { 0 };
         Unpack_Data(&Pack, &QoS, sizeof(QoS));
 
         SBN_Status = ProcessSubFromPeer(Peer, MsgID, QoS);
@@ -615,13 +615,13 @@ SBN_Status_t SBN_ProcessUnsubsFromPeer(SBN_PeerInterface_t *Peer, void *Msg)
         EVSSendInfo(SBN_PROTO_EID, "version number mismatch with peer CpuID %d", Peer->ProcessorID);
     }
 
-    uint16 SubCnt;
+    uint16 SubCnt = 0;
     Unpack_UInt16(&Pack, &SubCnt);
 
     int SubIdx = 0;
     for (SubIdx = 0; SubIdx < SubCnt; SubIdx++)
     {
-        CFE_SB_MsgId_t MsgID;
+        CFE_SB_MsgId_t MsgID = CFE_SB_INVALID_MSG_ID;
         Unpack_MsgID(&Pack, &MsgID);
         CFE_SB_Qos_t QoS;
         Unpack_Data(&Pack, &QoS, sizeof(QoS));


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #94 

**Testing performed**
GitHub Actions and CodeSonar

**Expected behavior changes**
Resolve CodeSonar warnings on uninitialized variables

**System(s) tested on**
GitHub Actions and CodeSonar. CodeSonar results will be posted on the internal ticket.

**Additional context**
The Build and Run workflow has been failing on dev before this PR. I was able to build SBN using the following commands when running CodeSonar

```
export SIMULATION=native OMIT_DEPRECATED=false BUILDTYPE=debug ENABLE_UNIT_TESTS=false
make native_std.prep
make -C build-native_std/native/default_cpu1/apps/sbn
```

Review the CodeSonar links on the internal ticket to see how these changes resolved the Uninitialized Variable warnings, but introduced other warnings.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH.