### PR TITLE
Part nasa/cFS#1079, Adding specialty PR templates and links to the specialty PR templates in the default PR template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Code snips**
+If applicable, add references to the software.
+
+**System observed on:**
+ - Hardware
+ - OS: [e.g. Linux 4.4]
+ - Versions [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps]
+
+**Additional context**
+Add any other context about the problem here.
+
+**Reporter Info**
+Full name and company/organization if applicable

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context about the feature request here.
+
+**Requester Info**
+Full name and company/organization if applicable

--- a/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
@@ -1,0 +1,50 @@
+---
+name: Comment / Documentation Change
+about: Changes limited to comments, README, docstrings, or other documentation
+labels: documentation
+---
+
+## Description of Change
+
+<!-- Briefly describe what documentation/comments were changed and why. -->
+
+## Linked Issue
+
+<!-- Required. Reference the GitHub issue this PR addresses, e.g., Closes #123 -->
+Closes #
+
+## Areas of Expertise Touched
+
+<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above/linked to this PR
+- [ ] Documentation generation workflow ran successfully on this branch
+- [ ] Changes are limited to documentation/comments (no code behavior changes)
+
+---
+
+## Reviewer Checklist
+
+- [ ] Documentation is clear, accurate, and complete
+- [ ] Spelling and grammar reviewed
+- [ ] Any links in the documentation have been verified to work
+- [ ] Documentation generation workflow output looks correct
+- [ ] Appropriate Expert areas have been reviewed

--- a/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
@@ -1,0 +1,88 @@
+---
+name: FSW Code Change
+about: Flight Software code changes
+labels: fsw
+---
+
+## Description of Change
+
+<!-- Describe what was changed, why, and how. Include any design notes that will help reviewers. -->
+
+## Linked Issue
+
+Closes #
+
+## Requirements Impact
+
+<!-- List any requirements impacted by this change. Indicate whether each was updated, or confirm the change continues to satisfy existing requirements. -->
+- Requirement ID(s):
+- [ ] Requirements updated as necessary
+- [ ] Existing requirements are still satisfied by this change
+
+## Testing Evidence
+
+<!-- Paste relevant test output, link to CI runs, or attach screenshots. -->
+
+### Unit Tests (UT Assert)
+<!-- Link to CI run or paste summary -->
+
+### COSMOS Test Suite
+<!-- Link to CI run, paste summary, or note "N/A — no relevant changes" -->
+
+## Areas of Expertise Touched
+
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above
+- [ ] Code has been formatted with `.clang-format`
+- [ ] Static analysis workflows ran and passed
+- [ ] Unit tests (UT Assert) updated/added to cover code changes
+- [ ] Unit test workflows ran and passed
+- [ ] COSMOS test suite was run; tests updated/added if relevant changes were made
+- [ ] Requirements have been reviewed; updated or confirmed still satisfied (see above)
+- [ ] Testing evidence is included above
+- [ ] Self-review of the diff completed
+
+---
+
+## Reviewer Checklist
+
+- [ ] Code logic is correct and matches the stated intent
+- [ ] Code is readable, maintainable, and follows project conventions
+- [ ] `.clang-format` has been applied
+- [ ] Static analysis results reviewed and acceptable
+- [ ] Unit tests are meaningful and adequately cover the changes
+- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
+- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
+- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
+- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
+- [ ] Requirements impact reviewed and appropriate
+- [ ] Error handling is appropriate
+- [ ] Appropriate Expert areas have been reviewed
+
+### Reviewer Testing Notes
+
+<!--
+Describe how you independently verified this change. For example:
+  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
+  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
+  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
+  - "Performed ad-hoc test by [describe scenario]; observed [result]."
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
@@ -1,0 +1,50 @@
+---
+name: Workflows Change
+about: Changes to files under .github/workflows/
+labels: ci/workflows
+---
+
+## Description of Change
+
+<!-- Describe what workflow(s) were changed and why. -->
+
+## Linked Issue
+
+Closes #
+
+## Areas of Expertise Touched
+
+- [ ] ASTRO
+- [ ] CI/CD
+- [ ] COSMOS
+- [ ] Cybersecurity
+- [ ] Docker
+- [ ] EDS
+- [ ] Git
+- [ ] PSPs
+- [ ] SBN
+- [ ] SMP
+- [ ] Tables
+- [ ] TSN
+- [ ] Unit Tests
+- [ ] Other
+
+---
+
+## Author Checklist
+
+- [ ] Linked GitHub issue is referenced above
+- [ ] Workflow changes were tested on a branch/fork before submitting this PR
+- [ ] All workflows ran successfully on this branch
+
+---
+
+## Reviewer Checklist
+
+- [ ] Workflow logic is correct and achieves the stated goal
+- [ ] Third-party actions are from trusted sources and pinned to a specific SHA/tag
+- [ ] Secrets are handled appropriately (no secrets exposed in logs, least-privilege usage)
+- [ ] Workflow permissions follow the principle of least privilege
+- [ ] Changes do not break or bypass existing branch protection rules
+- [ ] All workflow runs on this PR completed successfully
+- [ ] Appropriate Expert areas have been reviewed

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,35 @@
+**Describe the contribution**
+A clear and concise description of what the contribution is.
+- Include explicitly what issue it addresses [e.g. Fixes #X]
+
+**Testing performed**
+Steps taken to test the contribution:
+1. Build steps '...'
+1. Execution steps '...'
+
+**Expected behavior changes**
+A clear and concise description of how this contribution will change behavior and level of impact.
+ - API Change: xxx (if applicable)
+ - Behavior Change: xxx (if applicable)
+ - Or no impact to behavior
+
+**System(s) tested on**
+ - Hardware: [e.g. PC, SP0, MCP750]
+ - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
+ - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]
+
+**Additional context**
+Add any other context about the contribution here.
+
+**Third party code**
+If included, identify any third party code and provide text file of license
+
+**Contributor Info - All information REQUIRED for consideration of pull request**
+Full name and company/organization/center of all contributors ("Personal" if individual work)
+ - Note CLA's apply to software contributions.
+
+**For members of the cFS Team**
+Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
+- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
+- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
+- [Workflows Change](?expand=1&template=workflows_change.md)


### PR DESCRIPTION
## Description of Change

Adding specialty PR templates to this repository and adding links to these templates in the default PR template.

## Linked Issue

<!-- Required. Reference the GitHub issue this PR addresses, e.g., Closes #123 -->
Partially Closes nasa/cFS#1079

## Areas of Expertise Touched

<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above/linked to this PR
- [x] Documentation generation workflow ran successfully on this branch
- [x] Changes are limited to documentation/comments (no code behavior changes)

---

## Reviewer Checklist

- [ ] Documentation is clear, accurate, and complete
- [ ] Spelling and grammar reviewed
- [ ] Any links in the documentation have been verified to work
- [ ] Documentation generation workflow output looks correct
- [ ] Appropriate Expert areas have been reviewed