### PR TITLE
Fix spelling errors in SBN (#75)

### DIFF
--- a/fsw/platform_inc/sbn_interfaces.h
+++ b/fsw/platform_inc/sbn_interfaces.h
@@ -302,7 +302,7 @@ typedef struct
 /**
  * This structure contains function pointers to interface-specific versions
  * of the key SBN functions.  Every interface module must have an equivalent
- * structure that points to the approprate functions for that interface.
+ * structure that points to the appropriate functions for that interface.
  */
 struct SBN_IfOps_s
 {

--- a/fsw/platform_inc/sbn_types.h
+++ b/fsw/platform_inc/sbn_types.h
@@ -70,7 +70,7 @@ typedef enum
 } SBN_MsgTypeEnum_t;
 
 /**
- * Mask to identift module-specific message types
+ * Mask to identify module-specific message types
  */
 #define SBN_MODULE_SPECIFIC_MESSAGE_ID_MASK (0x80)
 

--- a/fsw/src/sbn_app.c
+++ b/fsw/src/sbn_app.c
@@ -284,7 +284,7 @@ typedef struct
 
 /**
  * \brief Receive task created for each direct peer-based connection.
- * Spanwed from PeerPoll()
+ * Spawned from PeerPoll()
  */
 void SBN_RecvPeerTask(void)
 {
@@ -370,7 +370,7 @@ typedef struct RecvNetTaskData_s
 
 /**
  * \brief Receive task created for each net-based connection.
- * Spanwed from PeerPoll()
+ * Spawned from PeerPoll()
  */
 void SBN_RecvNetTask(void)
 {
@@ -1023,7 +1023,7 @@ static SBN_Status_t WaitForWakeup(int32 iTimeOut)
             return SBN_ERROR;
     } /* end switch */
 
-    /* For sbn, we still want to perform cyclic processing
+    /* For SBN, we still want to perform cyclic processing
     ** if the WaitForWakeup time out
     ** cyclic processing at timeout rate
     */
@@ -1621,7 +1621,7 @@ void SBN_AppMain(void)
     Status = OS_MutSemCreate(&(SBN.ConfMutex), "sbn_conf_mutex", 0);
     if (Status != OS_SUCCESS)
     {
-        EVSSendErr(SBN_INIT_EID, "%s error creating mutex for configuiration", FAIL_PREFIX);
+        EVSSendErr(SBN_INIT_EID, "%s error creating mutex for configuration", FAIL_PREFIX);
         return;
     }
 
@@ -1807,7 +1807,7 @@ SBN_Status_t SBN_ProcessNetMsg(SBN_NetInterface_t *Net,
  * Find the PeerIndex for a given ProcessorID and net.
  * @param[in] Net The network interface to search.
  * @param[in] ProcessorID The ProcessorID of the peer being sought.
- * @param[in] SpacecraftID The SpacecraftI of the peer being sought.
+ * @param[in] SpacecraftID The SpacecraftID of the peer being sought.
  * @return The Peer interface pointer, or NULL if not found.
  */
 SBN_PeerInterface_t *

--- a/fsw/src/sbn_cmds.c
+++ b/fsw/src/sbn_cmds.c
@@ -499,7 +499,7 @@ static void ReloadTblCmd(CFE_MSG_Message_t *MsgPtr)
     else
     {
         EVSSendErr(SBN_CMD_EID,
-                   "Recevied tbl reload command, but message was wrong size. This command should only be "
+                   "Received tbl reload command, but message was wrong size. This command should only be "
                    "triggered from the TBL service, itself, and not called directly.");
     }
     return;

--- a/fsw/src/sbn_main_events.h
+++ b/fsw/src/sbn_main_events.h
@@ -21,7 +21,7 @@
 **
 **   2014/11/21 ejtimmon
 **
-**   Specification for the Software Bus Network event identifers.
+**   Specification for the Software Bus Network event identifiers.
 **
 *************************************************************************/
 

--- a/modules/protocol/dtn/fsw/src/sbn_dtn_if.c
+++ b/modules/protocol/dtn/fsw/src/sbn_dtn_if.c
@@ -153,7 +153,7 @@ int SBN_DTN_Send(SBN_PeerInterface_t *Peer, SBN_MsgType_t MsgType, SBN_MsgSz_t M
     return SBN_SUCCESS;
 } /* end SBN_DTN_Send */
 
-/* Note that this Recv function is indescriminate, packets will be received
+/* Note that this Recv function is indiscriminate, packets will be received
  * from all peers but that's ok, I just inject them into the SB and all is
  * good!
  */

--- a/modules/protocol/serial/fsw/src/sbn_serial_if.c
+++ b/modules/protocol/serial/fsw/src/sbn_serial_if.c
@@ -302,7 +302,7 @@ int SBN_SERIAL_Recv(SBN_NetInterface_t  *Net,
         } /* end if */
     } /* end if */
 
-    /* only get here if we're read'd the header and ready for the body */
+    /* only get here if we've read the header and ready for the body */
 
     ToRead = CFE_MAKE_BIG32(*((SBN_MsgSz_t *)&RecvBufs[PeerData->BufNum])) + SBN_PACKED_HDR_SZ - PeerData->RecvSz;
     if (ToRead)

--- a/modules/protocol/udp/fsw/src/sbn_udp_if.c
+++ b/modules/protocol/udp/fsw/src/sbn_udp_if.c
@@ -265,7 +265,7 @@ static SBN_Status_t Send(SBN_PeerInterface_t *Peer, SBN_MsgType_t MsgType, SBN_M
     } /* end if */
 } /* end Send() */
 
-/* Note that this Recv function is indescriminate, packets will be received
+/* Note that this Recv function is indiscriminate, packets will be received
  * from all peers but that's ok, I just inject them into the SB and all is
  * good!
  */


### PR DESCRIPTION
**Describe the contribution**

Fix spelling errors in comments and error strings identified in issue #75.

Fixes #75.

**Testing performed**

1. Reviewed the complete staged diff with `git diff --cached`.
2. Ran `git diff --cached --check` with no errors.
3. Verified the affected files contain the corrected spellings.
4. No functional code behavior was changed.

**Expected behavior changes**

No impact to behavior.

* API Change: None
* Behavior Change: None

**System(s) tested on**

* Hardware: PC
* OS: Linux
* Versions: Not applicable; changes are limited to comments and an error-message string.

**Additional context**

This contribution addresses the spelling errors listed in issue #75. The changes are limited to the reported comments and string.

**Third party code**

None.

**Contributor Info - All information REQUIRED for consideration of pull request**

Ega Hemachandra — Personal.
