### PR TITLE
Fix nasa#102, Replaced zero with NULL for MsgPtr initialization in WaitForWakeup() in sbn_app.c

### DIFF
--- a/fsw/src/sbn_app.c
+++ b/fsw/src/sbn_app.c
@@ -1006,7 +1006,7 @@ static SBN_Status_t WaitForWakeup(int32 iTimeOut)
 {
     CFE_Status_t       CFE_Status = CFE_SUCCESS;
     SBN_Status_t       SBN_Status = SBN_SUCCESS;
-    CFE_MSG_Message_t *MsgPtr     = 0;
+    CFE_MSG_Message_t *MsgPtr     = NULL;
 
     /* Wait for WakeUp messages from scheduler */
     CFE_Status = CFE_SB_ReceiveBuffer((CFE_SB_Buffer_t **)&MsgPtr, SBN.CmdPipe, iTimeOut);


### PR DESCRIPTION
Fixes #102 

**Testing performed**
GitHub Actions, Axle, CodeSonar

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
- Hardware: PC
- OS: Linux

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang / NASA GSFC

**For members of the cFS Team**
Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
- [Workflows Change](?expand=1&template=workflows_change.md)
